### PR TITLE
Underlay/mininet: Always install Flask

### DIFF
--- a/underlay/roles/configure-underlay/tasks/mininet.yml
+++ b/underlay/roles/configure-underlay/tasks/mininet.yml
@@ -12,7 +12,6 @@
 - name: install flask
   pip: 
     name: flask
-  when: mininet_result.stat.exists == False 
 
 - name: clone mininet
   git:


### PR DESCRIPTION
Closes #9  
mininet directory already existing doesn't always mean that Flask has been installed